### PR TITLE
"make clean" should delete Makefile.coq and Makefile.coq.conf

### DIFF
--- a/tuto0/Makefile
+++ b/tuto0/Makefile
@@ -2,13 +2,19 @@ ifeq "$(COQBIN)" ""
   COQBIN=$(dir $(shell which coqtop))/
 endif
 
+default_target: Makefile.coq
+	+make -f Makefile.coq all
+
 %: Makefile.coq
+	+make -f Makefile.coq $@
 
 Makefile.coq: _CoqProject
 	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
 
-tests: all
-	@$(MAKE) -C tests -s clean
-	@$(MAKE) -C tests -s all
+_CoqProject: ;
 
--include Makefile.coq
+clean: Makefile.coq
+	+make -f Makefile.coq clean
+	rm -f Makefile.coq Makefile.coq.conf .merlin
+
+.PHONY: default_target tests clean


### PR DESCRIPTION
If `make clean` does not delete `Makefile.coq` and `Makefile.coq.conf`, confusing problems can arise resulting in a lot of wasted time (see yesterday's [gitter](https://gitter.im/coq/coq) conversation between @Zimmi48 and @samuelgruetter).

This PR intends to fix this.

Also, I wasn't sure about the `tests` target, it seems there's no folder `tests`, so I removed it.