### PR TITLE
Adapting to Coq PR #8718: declare_definition now takes a UState.t + using new predefined no_hook

### DIFF
--- a/tuto1/src/simple_declare.ml
+++ b/tuto1/src/simple_declare.ml
@@ -9,9 +9,9 @@ let edeclare ident (_, poly, _ as k) ~opaque sigma udecl body tyopt imps hook =
      (Option.List.cons tyopt [body]) in
   let sigma = Evd.restrict_universe_context sigma uvars in
   let univs = Evd.check_univ_decl ~poly sigma udecl in
-  let ubinders = Evd.universe_binders sigma in
+  let ucontext = Evd.evar_universe_context sigma in
   let ce = Declare.definition_entry ?types:tyopt ~univs body in
-  DeclareDef.declare_definition ident k ce ubinders imps hook
+  DeclareDef.declare_definition ident k ce ucontext imps hook
 
 let packed_declare_definition ident value_with_constraints =
   let body, ctx = value_with_constraints in
@@ -19,7 +19,6 @@ let packed_declare_definition ident value_with_constraints =
   let k = (Decl_kinds.Global,
            Flags.is_universe_polymorphism(), Decl_kinds.Definition) in
   let udecl = UState.default_univ_decl in
-  let nohook = Lemmas.mk_hook (fun _ x -> ()) in
-  ignore (edeclare ident k ~opaque:false sigma udecl body None [] nohook)
+  ignore (edeclare ident k ~opaque:false sigma udecl body None [] Lemmas.no_hook)
 
 (* But this definition cannot be undone by Reset ident *)


### PR DESCRIPTION
Hi @ybertot, this is for compatibility with Coq PR #8718. It is not backward-compatible, so it needs synchronization.