### PR TITLE
[dune] Add support for building with Dune for the ML part.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Makefile.coq*
 *.vo
 *.glob
 *.aux
+*/*/.merlin

--- a/tuto0/src/dune
+++ b/tuto0/src/dune
@@ -1,0 +1,9 @@
+(library
+ (name tuto0_plugin)
+ (public_name coq.plugins.tutorial.p0)
+ (libraries coq.plugins.ltac))
+
+(rule
+ (targets g_tuto0.ml)
+ (deps (:pp-file g_tuto0.mlg) )
+ (action (run coqpp %{pp-file})))

--- a/tuto1/src/dune
+++ b/tuto1/src/dune
@@ -1,0 +1,9 @@
+(library
+ (name tuto1_plugin)
+ (public_name coq.plugins.tutorial.p1)
+ (libraries coq.plugins.ltac))
+
+(rule
+ (targets g_tuto1.ml)
+ (deps (:pp-file g_tuto1.mlg) )
+ (action (run coqpp %{pp-file})))

--- a/tuto2/src/dune
+++ b/tuto2/src/dune
@@ -1,0 +1,9 @@
+(library
+ (name tuto2_plugin)
+ (public_name coq.plugins.tutorial.p2)
+ (libraries coq.plugins.ltac))
+
+(rule
+ (targets demo.ml)
+ (deps (:pp-file demo.mlg) )
+ (action (run coqpp %{pp-file})))

--- a/tuto3/src/dune
+++ b/tuto3/src/dune
@@ -1,0 +1,9 @@
+(library
+ (name tuto3_plugin)
+ (public_name coq.plugins.tutorial.p3)
+ (libraries coq.plugins.ltac))
+
+(rule
+ (targets g_tuto3.ml)
+ (deps (:pp-file g_tuto3.mlg))
+ (action (run coqpp %{pp-file})))


### PR DESCRIPTION
This allows to drop the plugin_tutorials in the coq tree and have the
build compose.